### PR TITLE
support arm

### DIFF
--- a/btrfs.go
+++ b/btrfs.go
@@ -365,7 +365,7 @@ func openSubvolDir(path string) (*os.File, error) {
 }
 
 func isStatfsSubvol(statfs *syscall.Statfs_t) error {
-	if statfs.Type != C.BTRFS_SUPER_MAGIC {
+	if int64(statfs.Type) != int64(C.BTRFS_SUPER_MAGIC) {
 		return errors.Errorf("not a btrfs filesystem")
 	}
 


### PR DESCRIPTION
For https://github.com/docker/containerd/pull/644

(compilation error was `vendor/github.com/stevvooe/go-btrfs/btrfs.go:368: constant 2435016766 overflows int32`)
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>