### PR TITLE
Use go.mod to get vendored content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
     - ls /usr/include/btrfs
 
 install:
-    - go get -d ./...
+    - GO111MODULE="on" go mod vendor
     - go get -u github.com/vbatts/git-validation
     - go get -u github.com/kunalkushwaha/ltag
 


### PR DESCRIPTION
Also ignore vendor dir since we aren't checking in the vendored files.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>