### PR TITLE
fix slice size overflow on mipsle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This package may not cover all the use cases for btrfs. If something you need
 is missing, please don't hesitate to submit a PR.
 
 Note that due to struct alignment issues, this isn't yet fully native.
-Preferrably, this could be resolved, so contributions in this direction are
+Preferably, this could be resolved, so contributions in this direction are
 greatly appreciated.
 
 ## Applying License Header to New Files

--- a/doc.go
+++ b/doc.go
@@ -14,20 +14,5 @@
    limitations under the License.
 */
 
-/*
-  Copyright The containerd Authors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-*/
 // Package btrfs provides bindings for working with btrfs partitions from Go.
 package btrfs

--- a/helpers.go
+++ b/helpers.go
@@ -14,21 +14,6 @@
    limitations under the License.
 */
 
-/*
-  Copyright The containerd Authors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-*/
 package btrfs
 
 /*
@@ -66,7 +51,7 @@ var (
 )
 
 func uuidString(uuid *[C.BTRFS_UUID_SIZE]C.u8) string {
-	b := (*[1<<31 - 1]byte)(unsafe.Pointer(uuid))[:C.BTRFS_UUID_SIZE]
+	b := (*[maxByteSliceSize]byte)(unsafe.Pointer(uuid))[:C.BTRFS_UUID_SIZE]
 
 	if bytes.Equal(b, zeros) {
 		return ""

--- a/info.go
+++ b/info.go
@@ -14,21 +14,6 @@
    limitations under the License.
 */
 
-/*
-  Copyright The containerd Authors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-*/
 package btrfs
 
 // Info describes metadata about a btrfs subvolume.

--- a/ioctl.go
+++ b/ioctl.go
@@ -14,21 +14,6 @@
    limitations under the License.
 */
 
-/*
-  Copyright The containerd Authors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-*/
 package btrfs
 
 import "syscall"


### PR DESCRIPTION
Fix following errors on mipsle:

  src/github.com/containerd/btrfs/btrfs.go:133:15: type [2147483647]byte larger than address space
  src/github.com/containerd/btrfs/btrfs.go:274:15: type [2147483647]byte larger than address space
  src/github.com/containerd/btrfs/btrfs.go:310:15: type [2147483647]byte larger than address space
  src/github.com/containerd/btrfs/btrfs.go:369:15: type [2147483647]byte larger than address space
  src/github.com/containerd/btrfs/helpers.go:53:9: type [2147483647]byte larger than address space

Also fix some trivial document typos.

Fixes: #21