### PR TITLE
fix: checkptr issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 
 go:
   - "1.13.x"
+  - "1.15.x"
 
 before_install:
     - sudo apt-get update

--- a/btrfs.go
+++ b/btrfs.go
@@ -275,7 +275,7 @@ func SubvolCreate(path string) error {
 	if len(name) > C.BTRFS_PATH_NAME_MAX {
 		return errors.Errorf("%q too long for subvolume", name)
 	}
-	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(&args.name[0]))
+	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(&args.name[0]))[:C.BTRFS_PATH_NAME_MAX:C.BTRFS_PATH_NAME_MAX]
 	copy(nameptr[:C.BTRFS_PATH_NAME_MAX], []byte(name))
 
 	if err := ioctl(fp.Fd(), C.BTRFS_IOC_SUBVOL_CREATE, uintptr(unsafe.Pointer(&args))); err != nil {
@@ -311,7 +311,7 @@ func SubvolSnapshot(dst, src string, readonly bool) error {
 		return errors.Errorf("%q too long for subvolume", dstname)
 	}
 
-	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(name))
+	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(name))[:C.BTRFS_SUBVOL_NAME_MAX:C.BTRFS_SUBVOL_NAME_MAX]
 	copy(nameptr[:C.BTRFS_SUBVOL_NAME_MAX], []byte(dstname))
 
 	if readonly {
@@ -370,7 +370,7 @@ func SubvolDelete(path string) error {
 		return errors.Errorf("%q too long for subvolume", name)
 	}
 
-	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(&args.name[0]))
+	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(&args.name[0]))[:C.BTRFS_SUBVOL_NAME_MAX:C.BTRFS_SUBVOL_NAME_MAX]
 	copy(nameptr[:C.BTRFS_SUBVOL_NAME_MAX], []byte(name))
 
 	if err := ioctl(fp.Fd(), C.BTRFS_IOC_SNAP_DESTROY, uintptr(unsafe.Pointer(&args))); err != nil {


### PR DESCRIPTION
When use >= go1.14, the go will return the issue, like

```
checkptr: converted pointer straddles multiple allocations

goroutine 27 [running]:
runtime.throw(0xf8de9c, 0x3a)
        /usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc0004afd80 sp=0xc0004afd50 pc=0x6ac9f2
runtime.checkptrAlignment(0xc0004afe78, 0xeabac0, 0x1)
        /usr/local/go/src/runtime/checkptr.go:20 +0xc9 fp=0xc0004afdb0 sp=0xc0004afd80 pc=0x67baa9
github.com/containerd/containerd/vendor/github.com/containerd/btrfs.SubvolCreate(0xc0001b2040, 0x31, 0x0, 0x0)
        /root/go/src/github.com/containerd/containerd/vendor/github.com/containerd/btrfs/btrfs.go:278 +0x185 fp=0xc0004b0ea8 sp=0xc0004afdb0 pc=0x899e45
github.com/containerd/containerd/snapshots/btrfs.(*snapshotter).makeSnapshot(0xc0005322d0, 0x1042c40, 0xc00018a360, 0x2, 0xf6e78e, 0x4, 0x0, 0x0, 0xc00053c040, 0x1, ...)
        /root/go/src/github.com/containerd/containerd/snapshots/btrfs/btrfs.go:216 +0x386 fp=0xc0004b13b0 sp=0xc0004b0ea8 pc=0xe2a646
github.com/containerd/containerd/snapshots/btrfs.(*snapshotter).Prepare(0xc0005322d0, 0x1042c40, 0xc000020180, 0xf6e78e, 0x4, 0x0, 0x0, 0xc00053c040, 0x1, 0x1, ...)
        /root/go/src/github.com/containerd/containerd/snapshots/btrfs/btrfs.go:186 +0xd0 fp=0xc0004b1468 sp=0xc0004b13b0 pc=0xe2a050
github.com/containerd/containerd/snapshots/testsuite.baseTestSnapshots(0x1042c40, 0xc000020180, 0x1047ec0, 0xc0005322d0, 0x6be694, 0xc0005443e9)
        /root/go/src/github.com/containerd/containerd/snapshots/testsuite/testsuite.go:563 +0x11a fp=0xc0004b15b8 sp=0xc0004b1468 pc=0xe1951a
github.com/containerd/containerd/snapshots/testsuite.checkUpdate(0x1042c40, 0xc000020180, 0xc000083e00, 0x1047ec0, 0xc0005322d0, 0xc00052c300, 0x28)
        /root/go/src/github.com/containerd/containerd/snapshots/testsuite/testsuite.go:592 +0x125 fp=0xc0004b1c30 sp=0xc0004b15b8 pc=0xe1a065
github.com/containerd/containerd/snapshots/testsuite.makeTest.func1(0xc000083e00)
        /root/go/src/github.com/containerd/containerd/snapshots/testsuite/testsuite.go:117 +0x72e fp=0xc0004b1ed0 sp=0xc0004b1c30 pc=0xe244ee
testing.tRunner(0xc000083e00, 0xc000149590)
        /usr/local/go/src/testing/testing.go:1123 +0x203 fp=0xc0004b1fd0 sp=0xc0004b1ed0 pc=0x819ba3
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc0004b1fd8 sp=0xc0004b1fd0 pc=0x6e6401
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1168 +0x5bc
```

Should use (*[x]T)(ptr)[:n:m] to prevent the issue.

Reference: https://github.com/etcd-io/bbolt/issues/187#issuecomment-591718494

Signed-off-by: Wei Fu <fuweid89@gmail.com>