### PR TITLE
Update GitHub actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
 
   build:
     name: Btrfs CI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.19.x
       id: go
@@ -27,7 +27,7 @@ jobs:
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/github.com/containerd/btrfs
         fetch-depth: 25
@@ -40,4 +40,5 @@ jobs:
     - name: Build
       working-directory: src/github.com/containerd/btrfs
       run: |
+        sudo apt-get update && sudo apt-get install -y libbtrfs-dev
         make vet binaries


### PR DESCRIPTION
Update actions runner OS image from Ubuntu 18.04 to Ubuntu 22.04. Update actions/checkout and actions/setup-go packages from v2 to v3.

Related issue: https://github.com/containerd/project/issues/95

Signed-off-by: Austin Vazquez <macedonv@amazon.com>