### PR TITLE
Upgrade Go compiler from Go 1.16 to Go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.19.x
       id: go
 
     - name: Setup environment

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/containerd/btrfs
 
-go 1.16
+go 1.19


### PR DESCRIPTION
Upgrading Go compiler from Go 1.16 to Go 1.19

Signed-off-by: Austin Vazquez <macedonv@amazon.com>