### PR TITLE
fix make test failed on old kernel when run make test on containerd 1.7

### DIFF
--- a/btrfs.h
+++ b/btrfs.h
@@ -16,7 +16,7 @@
 
 #include <linux/version.h>
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
-#error "Headers from kernel >= 4.12 are required on compilation time (not on run time)"
+#warning "Headers from kernel >= 4.12 are required on compilation time (not on run time)"
 #endif
 #include <linux/btrfs.h>
 #include <linux/btrfs_tree.h>


### PR DESCRIPTION
'BUILDTAGS=no_btrfs make test' or 'make test ' on 3.10 kernel for containerd 1.7
will show 
```
# github.com/containerd/btrfs/v2
In file included from vendor/github.com/containerd/btrfs/v2/btrfs.go:23:0:
./btrfs.h:19:2: error: #error "Headers from kernel >= 4.12 are required on compilation time (not on run time)"
 #error "Headers from kernel >= 4.12 are required on compilation time (not on run time)"
```
BUILDTAGS=no_btrfs is useless
another pr https://github.com/containerd/btrfs/pull/43/files